### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,7 @@ author=shapoco
 email=shapoco@gmail.com
 sentence=A lightweight ArrayList library for Arduino.
 paragraph=A lightweight ArrayList library for Arduino.
+category=Data Processing
 url=https://github.com/shapoco/FixedSizeArrayList
 architectures=*
 core-dependencies=arduino (>=1.5.0)


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category '' in library FixedSizeArrayList is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format